### PR TITLE
Future-proof a dependency on type inference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl<Src: Iterator<Item=PathBuf>> MultiFileReadahead<Src>  {
     fn advance(&mut self) {
         let mut budget = self.budget;
 
-        budget -= self.open.iter().map(|o| o.prefetch_pos.saturating_sub(o.read_pos)).sum();
+        budget -= self.open.iter().map(|o| o.prefetch_pos.saturating_sub(o.read_pos)).sum::<u64>();
 
         for i in 0.. {
             if budget < 64 * 1024 { break; }


### PR DESCRIPTION
In the Rust compiler, a pull request is being considered (see GitHub PR rust-lang/rust#41336) that will add support for `a -= &b` (instead of only `a -= b`) for numeric types like `i64` and `f64`. This helps when writing generic code.

Unfortunately, this breaks the build of reapfrog, because reapfrog currently does the following:

`budget -= self.open.iter().map(|o| o.prefetch_pos.saturating_sub(o.read_pos)).sum();`

Rust is currently able to infer that `sum()` really means `sum::<u64>()`, because the result gets subtracted from a `u64`. But if the PR on the compiler is accepted, this type inference will no longer be possible, because sum() could then also be `sum::<&'a u64>` for some lifetime `'a`.

This commit specifies the output type of sum() explicitly, so that it doesn't require any type inference.